### PR TITLE
Fix exception in TP caused by wrongly referenced array length

### DIFF
--- a/Assets/DoubleOn/Scripts/DoubleOnModule.cs
+++ b/Assets/DoubleOn/Scripts/DoubleOnModule.cs
@@ -177,7 +177,7 @@ public class DoubleOnModule : ModuleScript {
 		if (new HashSet<int>(btnIndices).Count != btnIndices.Length) yield break;
 		int[][] colInd = subCommands.Select(s => s.Skip(s.Length - 2).Select(c => _colorIndsDecoder[COLOR_SHORT_NAMES.IndexOf(c.ToUpper())]).ToArray()).ToArray();
 		yield return null;
-		if (btnIndices.Any(b => b >= _puzzle.ButtonPositions.Length)) {
+		if (btnIndices.Any(b => b >= _puzzle.LEDPositions.Length)) {
 			yield return "sendtochaterror {0}, !{1} invalid LED id.";
 			yield break;
 		}


### PR DESCRIPTION
For example, if you typed the command !# 12cc and the module only has 10 LEDs the module would throw an exception as the boundary range was set to 1 to the number of buttons instead of 1 to the number of LEDs.